### PR TITLE
Disable device orientation listener to prevent native controls glitch

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -256,14 +256,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             object: nil
         )
 
-        #if os(iOS)
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(handleRotation),
-                name: UIDevice.orientationDidChangeNotification,
-                object: nil
-            )
-        #endif
+        // This causes controls glitch when device rotates but app orientation is locked
+        // #if os(iOS)
+            // NotificationCenter.default.addObserver(
+            //     self,
+            //     selector: #selector(handleRotation),
+            //     name: UIDevice.orientationDidChangeNotification,
+            //     object: nil
+            // )
+        // #endif
 
         _playerObserver._handlers = self
         #if USE_VIDEO_CACHING


### PR DESCRIPTION
When using native iOS controls with `react-native-video`, the native player controls briefly jump and shift position during playback when the device's physical orientation changes, even though the app orientation is locked to portrait mode.

The `RCTVideo` class registers an observer for `UIDevice.orientationDidChangeNotification` which triggers `handleRotation()` whenever the device is physically rotated. This method updates the `playerViewController` frame using `UIScreen.main.bounds`, which returns bounds for the device orientation rather than the app orientation. When the app is locked to portrait but the device rotates to landscape, this creates a mismatch that causes the native controls to briefly render at incorrect positions before correcting themselves.

This PR disables the device orientation observer in `ios/Video/RCTVideo.swift` by commenting out the `NotificationCenter.default.addObserver` call for `UIDevice.orientationDidChangeNotification`. This fix prevents unnecessary layout updates when the device rotates but the app orientation remains locked, eliminating the controls glitch without impacting apps that allow rotation or fullscreen functionality.