### PR TITLE
Fix android `EventBuilder` type for React Native 0.81.5

### DIFF
--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -288,12 +288,28 @@ class VideoEventEmitter {
         }
     }
 
+    private class VideoEvent(
+        surfaceId: Int,
+        viewId: Int,
+        private val mEventName: String,
+        private val mEventData: WritableMap?
+    ) : Event<VideoEvent>(surfaceId, viewId) {
+        override fun getEventName() = mEventName
+        override fun getEventData() = mEventData
+    }
+
     private class EventBuilder(private val surfaceId: Int, private val viewId: Int, private val dispatcher: EventDispatcher) {
-        fun dispatch(event: EventTypes, paramsSetter: (WritableMap.() -> Unit)? = null) =
-            dispatcher.dispatchEvent(object : Event<Event<*>>(surfaceId, viewId) {
-                override fun getEventName() = "top${event.eventName.removePrefix("on")}"
-                override fun getEventData() = Arguments.createMap().apply(paramsSetter ?: {})
-            })
+        fun dispatch(event: EventTypes, paramsSetter: (WritableMap.() -> Unit)? = null) {
+            val eventData = Arguments.createMap().apply(paramsSetter ?: {})
+            dispatcher.dispatchEvent(
+                VideoEvent(
+                    surfaceId,
+                    viewId,
+                    "top${event.eventName.removePrefix("on")}",
+                    eventData
+                )
+            )
+        }
     }
 
     private fun audioTracksToArray(audioTracks: java.util.ArrayList<Track>?): WritableArray =


### PR DESCRIPTION
  ## Summary
  Fixes type issue in Android `EventBuilder` to support React Native 0.81.5 (required for Expo 54 upgrade).

  ## Changes
  Replaced anonymous `Event<Event<*>>` object with a proper `VideoEvent` class that extends `Event<VideoEvent>`. This
  resolves type compatibility issues with newer React Native versions.

  ## Context
  The previous implementation used a recursive generic type that is not compatible with React Native 0.81.5's stricter
  type checking.