### PR TITLE
Watch time is not tracked when screen is off

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -15,7 +15,9 @@ import android.app.RemoteAction;
 import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.BroadcastReceiver;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -210,6 +212,8 @@ public class ReactExoplayerView extends FrameLayout implements
 
     private View overlayView;
     private WindowManager windowManager;
+    private BroadcastReceiver screenOffReceiver;
+    private boolean isScreenOffReceiverRegistered = false;
     private boolean isBuffering;
     private boolean muted = false;
     public boolean enterPictureInPictureOnLeave = false;
@@ -362,13 +366,14 @@ public class ReactExoplayerView extends FrameLayout implements
             params.y = 0;
 
             windowManager.addView(overlayView, params);
-           
+            registerScreenOffReceiver();
         } catch (Exception e) {
             overlayView = null;
         }
     }
 
     private void hideOverlay() {
+        unregisterScreenOffReceiver();
         if (overlayView != null && windowManager != null) {
             try {
                 windowManager.removeView(overlayView);
@@ -377,6 +382,59 @@ public class ReactExoplayerView extends FrameLayout implements
             }
             overlayView = null;
         }
+    }
+
+    // Bring the app to foreground when screen turns off while in background.
+    private void bringAppToForeground() {
+        Context context = getContext();
+        if (context == null) return;
+
+        try {
+            ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            if (am != null) {
+                java.util.List<ActivityManager.AppTask> tasks = am.getAppTasks();
+                if (tasks != null && !tasks.isEmpty()) {
+                    tasks.get(0).moveToFront();
+                }
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void registerScreenOffReceiver() {
+        if (isScreenOffReceiverRegistered) return;
+
+        Context context = getContext();
+        if (context == null) return;
+
+        screenOffReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                    if (isInBackground && player != null && player.isPlaying()) {
+                        bringAppToForeground();
+                    }
+                }
+            }
+        };
+
+        IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
+        context.getApplicationContext().registerReceiver(screenOffReceiver, filter);
+        isScreenOffReceiverRegistered = true;
+    }
+
+    private void unregisterScreenOffReceiver() {
+        if (!isScreenOffReceiverRegistered || screenOffReceiver == null) return;
+
+        Context context = getContext();
+        if (context == null) return;
+
+        try {
+            context.getApplicationContext().unregisterReceiver(screenOffReceiver);
+        } catch (Exception ignored) {
+        }
+        screenOffReceiver = null;
+        isScreenOffReceiverRegistered = false;
     }
 
     public double getPositionInFirstPeriodMsForCurrentWindow(long currentPosition) {


### PR DESCRIPTION
## Problem
On Samsung devices with Android 16 (OneUI 8.0), the JS runtime freezes when the app is in background **AND** the screen turns off. This is caused by Samsung's Background Battery Analyzer (BBA) which suspends apps without visible windows.

The existing 1px overlay workaround works for: 
- App in foreground + screen off ✅ 
- App in background + screen on ✅ 

But fails for: 
- App in background + screen off ❌
 
## Solution
Register a BroadcastReceiver for `ACTION_SCREEN_OFF` that brings the app to foreground using `ActivityManager.AppTask.moveToFront()` when the screen turns off while playing in background. Since the screen is off, the user doesn't notice the app coming to foreground, but the JS runtime stays alive. 

The receiver is integrated with the overlay lifecycle - registered in `showOverlay()` and unregistered in `hideOverlay()`. This ensures it only runs on devices where overlay permission is granted (Samsung Android 16 with OneUI 8.0).

## Considerations 
- `moveToFront()` requires `SYSTEM_ALERT_WINDOW` permission (already required for overlay workaround) 
- No additional permission needed beyond what's already granted

## Demo
https://github.com/user-attachments/assets/24693902-f320-4f51-af83-5fe7051af63f


