### PR TITLE
Disable native CC button in AVPlayerViewController during AirPlay

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -43,6 +43,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _allowsExternalPlayback = true
     private var _selectedTextTrackCriteria: SelectedTrackCriteria = .none()
     private var _selectedAudioTrackCriteria: SelectedTrackCriteria = .none()
+    private weak var _subtitleButton: UIView?
     private var _playbackStalled = false
     private var _playInBackground = false
     private var _preventsDisplaySleepDuringVideoPlayback = true
@@ -1667,10 +1668,36 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 _playerLayer?.player = nil
                 _playerViewController?.player = nil
             }
+
+            setSubtitleButtonDisabled(_player.isExternalPlaybackActive)
+
             guard onVideoExternalPlaybackChange != nil else { return }
             onVideoExternalPlaybackChange?(["isExternalPlaybackActive": NSNumber(value: _player.isExternalPlaybackActive),
                                             "target": reactTag as Any])
         #endif
+    }
+
+    // Disables the native CC button in AVPlayerViewController when AirPlay is active.
+    private func setSubtitleButtonDisabled(_ disabled: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if disabled, _subtitleButton == nil, let playerVC = _playerViewController {
+                _subtitleButton = Self.findSubtitleButton(in: playerVC.view)
+            }
+            _subtitleButton?.alpha = disabled ? 0.2 : 1.0
+            _subtitleButton?.isUserInteractionEnabled = !disabled
+            if !disabled { _subtitleButton = nil }
+        }
+    }
+
+    private static func findSubtitleButton(in view: UIView) -> UIView? {
+        if let button = view as? UIButton,
+           let image = button.currentImage,
+           image.isSymbolImage,
+           image.description.contains("captions.bubble") {
+            return button
+        }
+        return view.subviews.lazy.compactMap { findSubtitleButton(in: $0) }.first
     }
 
     func handleViewControllerOverlayViewFrameChange(overlayView _: UIView, change: NSKeyValueObservedChange<CGRect>) {


### PR DESCRIPTION
Problem 
When AirPlay is active, the user can change subtitle language both in the app (via the native CC button) and on the 
AirPlay device, which can lead to conflicts. Subtitle selection should only be possible through the AirPlay device 
controls (when AirPlay connected with non Apple devices). 

Solution 
- Disable the native CC button in `AVPlayerViewController` when AirPlay is active
- Restore the button when AirPlay disconnects 
- Find the CC button by matching the `captions.bubble` SF Symbol 

Considerations 
- Apple does not provide a public API to selectively hide or disable the CC button in AVPlayerViewController.
- On other Apple device works well

Demo:
non Apple device:

<img width="603" height="1311" alt="IMG_1346" src="https://github.com/user-attachments/assets/65948222-8509-403f-a356-f643188f6387" />

with Apple device:

<img width="603" height="1311" alt="IMG_1347" src="https://github.com/user-attachments/assets/170753c7-834d-4988-8305-3b91731fe0f6" />



