### PR TITLE
Fix ANR in VideoPlaybackService by removing blocking loadBitmap

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -202,7 +202,8 @@ class VideoPlaybackService : MediaSessionService() {
                 .setContentTitle(session.player.mediaMetadata.title)
                 .setContentText(session.player.mediaMetadata.description)
                 .setContentIntent(PendingIntent.getActivity(this, 0, returnToPlayer, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
-                .setLargeIcon(session.player.mediaMetadata.artworkUri?.let { session.bitmapLoader.loadBitmap(it).get() })
+                // Skip large icon — loadBitmap().get() blocks the main thread and causes ANRs.
+                // On Android 13+ artwork is handled automatically via MediaStyle.
                 .setOngoing(true)
                 .build()
         }


### PR DESCRIPTION
Sentry issues [REACT-NATIVE-MY](https://dreaming-languages-inc.sentry.io/issues/6738171352/?project=4506896613769216&query=is%3Aunresolved%20ANR&referrer=issue-stream) (64 events, 15 users) and [REACT-NATIVE-HE](https://dreaming-languages-inc.sentry.io/issues/6607619680/?project=4506896613769216&query=is%3Aunresolved%20ANR&referrer=issue-stream) (37 events, 9 users) show the main thread blocked at: 

```
VideoPlaybackService in buildNotification at line 205 
FluentFuture$TrustedFuture in get 
AbstractFuture in get 
LockSupport in park 
Unsafe in the park 
```

`buildNotification()` calls `loadBitmap(uri).get()` to set the large artwork icon on the media notification. This 
blocks the main thread while waiting for the bitmap to load from disk or network. If it takes too long, Android calls ANR. 

The fix removes the blocking `.get()` call. The notification still shows title, description, playback controls, and the 
small icon in the status bar — just without the large artwork image visible when the notification is expanded. He Android 
13+ this code path was never used anyway, since artwork is handled automatically via MediaStyle.