### PR TITLE
Fix expo-plugin to use 'react-native-video-legacy' as createRunOncePl…

### DIFF
--- a/src/expo-plugins/withRNVideo.ts
+++ b/src/expo-plugins/withRNVideo.ts
@@ -56,4 +56,8 @@ const withRNVideo: ConfigPlugin<ConfigProps> = (config, props = {}) => {
   return config;
 };
 
-export default createRunOncePlugin(withRNVideo, pkg.name, pkg.version);
+export default createRunOncePlugin(
+  withRNVideo,
+  'react-native-video-legacy',
+  pkg.version,
+);


### PR DESCRIPTION
The package's internal name is still `react-native-video`, which collides with v7 when both are listed as Expo plugins in the same app - `createRunOncePlugin` keys by name, so whichever plugin runs first wins and the other is silently skipped. 

Hardcoding the key to `react-native-video-legacy` lets both plugins coexist.