### PR TITLE
Guard startForeground calls with try/catch and add isForeground flag

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -28,6 +28,7 @@ class VideoPlaybackService : MediaSessionService() {
     private var mediaSessionsList = mutableMapOf<ExoPlayer, MediaSession>()
     private var binder = PlaybackServiceBinder(this)
     private var sourceActivity: Class<Activity>? = null
+    private var isForeground = false
 
     // Controls for Android 13+ - see buildNotification function
     private val commandSeekForward = SessionCommand(COMMAND.SEEK_FORWARD.stringValue, Bundle.EMPTY)
@@ -65,7 +66,12 @@ class VideoPlaybackService : MediaSessionService() {
         addSession(mediaSession)
 
         val notificationId = player.hashCode()
-        startForeground(notificationId, buildNotification(mediaSession))
+        try {
+            startForeground(notificationId, buildNotification(mediaSession))
+            isForeground = true
+        } catch (e: Exception) {
+            DebugLog.e(TAG, "Failed to start foreground service: " + e.message)
+        }
     }
 
     fun unregisterPlayer(player: ExoPlayer) {
@@ -249,8 +255,13 @@ class VideoPlaybackService : MediaSessionService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForeground(PLACEHOLDER_NOTIFICATION_ID, createPlaceholderNotification())
+        try {
+            if (!isForeground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForeground(PLACEHOLDER_NOTIFICATION_ID, createPlaceholderNotification())
+                isForeground = true
+            }
+        } catch (e: Exception) {
+            DebugLog.e(TAG, "Failed to start foreground service: " + e.message)
         }
 
         intent?.let {


### PR DESCRIPTION
## Problem 
Google Play Console flags our production releases with a "Restricted foreground service types" warning, pointing at `com.brentvatne.exoplayer.VideoPlaybackService.onStartCommand`. Apps targeting Android 15+ cannot start `mediaPlayback` foreground services from `BOOT_COMPLETED` receivers, and Play's static analysis flags the unconditional `startForeground()` call as a potential crash path

## Solution 
- Port the foreground-start guard from the v7 player service: the `onStartCommand` change is a copy of v7's `isForeground` flag + try/catch around the placeholder notification
- Apply the same pattern to `registerPlayer`'s `startForeground()` call - this call site only exists in the legacy service (v7 uses `setMediaNotificationProvider` instead)

cc: @sharnik @szymonkoper @mobily